### PR TITLE
Jitcdde optimisation

### DIFF
--- a/DDEs_models_test/2delays.py
+++ b/DDEs_models_test/2delays.py
@@ -46,7 +46,7 @@ f = [ -y_jit(0,t_jit-tau1) -y_jit(0,t_jit-tau2)]
 DDE = jitcdde(f)
 DDE.set_integration_parameters(atol=atol,rtol=rtol)
 DDE.constant_past(y0)
-DDE.step_on_discontinuities()
+DDE.adjust_diff()
 print(DDE.t)
 data = []
 t_jit = np.linspace(DDE.t+0.01, tf+0.01, 101)

--- a/DDEs_models_test/divergingDDE.py
+++ b/DDEs_models_test/divergingDDE.py
@@ -71,7 +71,7 @@ f = [ y_jit(0,t_jit-tau)]
 DDE = jitcdde(f)
 DDE.set_integration_parameters(atol=atol,rtol=rtol)
 DDE.constant_past(y0)
-DDE.step_on_discontinuities()
+DDE.adjust_diff()
 data = []
 t_jit = np.linspace(DDE.t+0.01, tf, 101)
 dt_jit = []

--- a/DDEs_models_test/divergingJumpsDDE.py
+++ b/DDEs_models_test/divergingJumpsDDE.py
@@ -57,7 +57,6 @@ DDE.add_past_point(-ε,1,0)
 DDE.add_past_point( 0,1,1)
 DDE.initial_discontinuities_handled = True
 
-DDE.adjust_diff()
 data = []
 dt_jit = []
 times = np.linspace(DDE.t+0.01, tf, 101)

--- a/DDEs_models_test/divergingJumpsDDE.py
+++ b/DDEs_models_test/divergingJumpsDDE.py
@@ -47,7 +47,15 @@ DDE = jitcdde(f,
 		max_delay=20 # for plotting; lest history is forgotten
 	)
 DDE.set_integration_parameters(atol=atol,rtol=rtol)
-DDE.past_from_function(h,times_of_interest=np.linspace(-1.1,-1e-8,10))
+
+ε = 1e-8
+DDE.add_past_point(-1,1,0)
+for i,x in enumerate(np.arange(-0.8,-0.2,0.2)):
+	DDE.add_past_point(x-ε,(-1)** i   ,0)
+	DDE.add_past_point(x+ε,(-1)**(i+1),0)
+DDE.add_past_point(-ε,1,0)
+DDE.add_past_point( 0,1,1)
+DDE.initial_discontinuities_handled = True
 
 DDE.adjust_diff()
 data = []


### PR DESCRIPTION
I changed some of the JiTCDDE codes to better use its features. This causes it to perform better in the benchmarks. The main reason for this is that for the benchmarks, an exact handling of the initial conditions really matters, while it is not so relevant for the applications JiTCDDE was intended for.